### PR TITLE
[codex] Persist memory data in Coolify deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,6 +37,11 @@ frontend/.next/
 # Data and logs
 data/
 logs/
+memory_db/
+persistent_data/
+knowledge_base/
+backups/
+scratchpad/
 *.log
 
 # Tests

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ LOG_FILE=agent.log
 
 # Memory Configuration
 MEMORY_PERSIST_DIRECTORY=./memory_db
+PERSISTENT_DATA_DIR=./persistent_data
 MEMORY_COLLECTION_NAME=agent_memory
 MAX_MEMORY_ENTRIES=10000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,26 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy application code
 COPY . .
 
+# Runtime storage defaults. These paths are mounted as persistent volumes by
+# docker-compose.yaml and should be configured as persistent storage in Coolify
+# if deploying this Dockerfile directly.
+ENV MEMORY_PERSIST_DIRECTORY=/app/data/memory_db \
+    PERSISTENT_DATA_DIR=/app/data/persistent_data \
+    KNOWLEDGE_BASE_PATH=/app/data/knowledge_base \
+    BACKUP_DIRECTORY=/app/data/backups \
+    SCRATCHPAD_DIR=/app/data/scratchpad \
+    LOG_FILE=/app/logs/agent.log
+
 # Create necessary directories
-RUN mkdir -p /app/data /app/logs
+RUN mkdir -p \
+    /app/data/memory_db \
+    /app/data/persistent_data \
+    /app/data/knowledge_base \
+    /app/data/backups \
+    /app/data/scratchpad \
+    /app/logs
+
+VOLUME ["/app/data/memory_db", "/app/data/persistent_data", "/app/data/knowledge_base", "/app/data/backups", "/app/data/scratchpad", "/app/logs"]
 
 # Default port (overridable via PORT env var in Coolify/hosting)
 ENV PORT=8000

--- a/coolify.json
+++ b/coolify.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://cdn.coollabs.io/coolify/coolify.schema.json",
   "build": {
-    "build_pack": "dockerfile"
+    "build_pack": "dockercompose",
+    "docker_compose_location": "./docker-compose.yaml"
   },
   "network": {
     "expose": "8000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,7 @@ services:
 
       # Memory Configuration (ChromaDB)
       - MEMORY_PERSIST_DIRECTORY=/app/data/memory_db
+      - PERSISTENT_DATA_DIR=/app/data/persistent_data
       - MEMORY_COLLECTION_NAME=${MEMORY_COLLECTION_NAME:-agent_memory}
       - MAX_MEMORY_ENTRIES=${MAX_MEMORY_ENTRIES:-10000}
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -16,20 +16,22 @@ This guide covers deploying the Evolving AI Agent to Coolify (backend) and Verce
 
 1. Log in to your Coolify dashboard
 2. Click **"+ New Resource"**
-3. Select **"Docker Compose"** or **"Dockerfile"**
+3. Select **"Docker Compose"**
 4. Choose your GitHub repository: `DavinciDreams/evolving-ai`
 5. Select branch: `main`
 
 ### Step 2: Configure Build Settings
 
-**If using Dockerfile:**
-- Build context: `/`
-- Dockerfile location: `./Dockerfile`
+- Build pack: `Docker Compose`
+- Base directory: `/`
+- Compose file: `./docker-compose.yaml`
 - Port: `8000`
 
-**If using Docker Compose:**
-- Compose file: `./docker-compose.yml`
-- Port: `8000`
+Use Docker Compose for production. The compose file mounts named volumes for
+ChromaDB, session state, knowledge, backups, scratchpad data, and logs. A plain
+Dockerfile deployment can run the app, but you must add the same persistent
+storage mounts in Coolify manually or memory will be lost when the container is
+recreated.
 
 ### Step 3: Set Environment Variables
 
@@ -38,18 +40,18 @@ In Coolify, add these environment variables:
 **Required:**
 ```bash
 # LLM Provider (choose one)
-LLM_PROVIDER=openai
+DEFAULT_LLM_PROVIDER=openai
 OPENAI_API_KEY=sk-...
 
 # Or use Anthropic
-LLM_PROVIDER=anthropic
+DEFAULT_LLM_PROVIDER=anthropic
 ANTHROPIC_API_KEY=sk-ant-...
 
 # Or use OpenRouter
-LLM_PROVIDER=openrouter
+DEFAULT_LLM_PROVIDER=openrouter
 OPENROUTER_API_KEY=sk-or-...
 
-MODEL_NAME=gpt-4  # or claude-3-opus-20240229, etc.
+DEFAULT_MODEL=gpt-4o-mini  # or your preferred provider model
 ```
 
 **Optional but Recommended:**
@@ -62,7 +64,7 @@ ENABLE_SELF_MODIFICATION=false
 # Discord Integration
 DISCORD_ENABLED=false
 DISCORD_BOT_TOKEN=your_discord_bot_token
-DISCORD_ALLOWED_CHANNEL_IDS=123456789,987654321
+DISCORD_CHANNEL_IDS=123456789,987654321
 
 # Web Search
 WEB_SEARCH_ENABLED=true
@@ -71,12 +73,33 @@ TAVILY_API_KEY=tvly-...
 SERPAPI_KEY=your_serpapi_key
 
 # Memory
-CHROMA_PERSIST_DIR=/app/data/chroma
-MEMORY_COLLECTION_NAME=agent_memories
+MEMORY_PERSIST_DIRECTORY=/app/data/memory_db
+PERSISTENT_DATA_DIR=/app/data/persistent_data
+MEMORY_COLLECTION_NAME=agent_memory
+KNOWLEDGE_BASE_PATH=/app/data/knowledge_base
+BACKUP_DIRECTORY=/app/data/backups
+SCRATCHPAD_DIR=/app/data/scratchpad
 
 # Logging
 LOG_LEVEL=INFO
+LOG_FILE=/app/logs/agent.log
 ```
+
+### Persistent Volumes
+
+`docker-compose.yaml` defines these production volumes:
+
+```text
+evolving-ai-memory       -> /app/data/memory_db
+evolving-ai-persistent   -> /app/data/persistent_data
+evolving-ai-knowledge    -> /app/data/knowledge_base
+evolving-ai-backups      -> /app/data/backups
+evolving-ai-scratchpad   -> /app/data/scratchpad
+evolving-ai-logs         -> /app/logs
+```
+
+After deploying, verify Coolify created or attached these storages before
+testing reboot persistence.
 
 ### Step 4: Deploy
 

--- a/evolving_agent/self_modification/agent_pr_manager.py
+++ b/evolving_agent/self_modification/agent_pr_manager.py
@@ -17,6 +17,7 @@ from .code_analyzer import CodeAnalyzer
 from .modifier import CodeModifier
 from .validator import CodeValidator
 from ..integrations.github_integration import GitHubIntegration
+from ..utils.config import config
 
 
 class AgentPRManager:
@@ -43,7 +44,9 @@ class AgentPRManager:
         self.validator = code_validator
 
         # Track improvement history
-        self.improvement_history_file = Path("persistent_data/improvement_history.json")
+        self.improvement_history_file = (
+            Path(config.persistent_data_dir) / "improvement_history.json"
+        )
         self.improvement_history = self._load_improvement_history()
 
         logger.info("AgentPRManager initialized")

--- a/evolving_agent/utils/config.py
+++ b/evolving_agent/utils/config.py
@@ -60,6 +60,14 @@ class Config:
         return os.getenv("MEMORY_PERSIST_DIRECTORY", "./memory_db")
 
     @property
+    def persistent_data_dir(self) -> str:
+        """Get persistent data directory for sessions, state, and SQLite data."""
+        return os.getenv(
+            "PERSISTENT_DATA_DIR",
+            str(Path(self.memory_persist_directory).parent / "persistent_data"),
+        )
+
+    @property
     def memory_collection_name(self) -> str:
         """Get memory collection name."""
         return os.getenv("MEMORY_COLLECTION_NAME", "agent_memory")
@@ -301,6 +309,7 @@ class Config:
             "log_level": self.log_level,
             "log_file": self.log_file,
             "memory_persist_directory": self.memory_persist_directory,
+            "persistent_data_dir": self.persistent_data_dir,
             "memory_collection_name": self.memory_collection_name,
             "max_memory_entries": self.max_memory_entries,
             "default_llm_provider": self.default_llm_provider,
@@ -350,6 +359,7 @@ class Config:
         """Ensure all required directories exist."""
         directories = [
             self.memory_persist_directory,
+            self.persistent_data_dir,
             self.backup_directory,
             self.knowledge_base_path,
             self.scratchpad_dir,

--- a/evolving_agent/utils/persistent_storage.py
+++ b/evolving_agent/utils/persistent_storage.py
@@ -20,20 +20,25 @@ class PersistentDataManager:
     """Manages persistent storage for all agent components."""
 
     def __init__(self):
-        self.data_dir = Path(config.memory_persist_directory).parent / "persistent_data"
+        self._configure_paths()
+
+        self.session_id = None
+        self.session_start_time = None
+
+    def _configure_paths(self):
+        """Refresh storage paths from environment-backed configuration."""
+        self.data_dir = Path(config.persistent_data_dir)
         self.session_file = self.data_dir / "session_data.json"
         self.agent_state_file = self.data_dir / "agent_state.json"
         self.interactions_db = self.data_dir / "interactions.db"
         self.evaluations_file = self.data_dir / "evaluations.json"
         self.modifications_log = self.data_dir / "modifications.json"
 
-        self.session_id = None
-        self.session_start_time = None
-
     async def initialize(self):
         """Initialize persistent data manager."""
         try:
             logger.info("Initializing persistent data manager...")
+            self._configure_paths()
 
             # Ensure data directory exists
             self.data_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_persistent_storage.py
+++ b/tests/test_persistent_storage.py
@@ -5,17 +5,17 @@ Test persistent storage functionality.
 
 import os
 import sys
+import asyncio
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-import asyncio
-import os
-import sys
-
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 import pytest
 
-from evolving_agent.utils.persistent_storage import persistent_data_manager
+from evolving_agent.utils.persistent_storage import (
+    PersistentDataManager,
+    persistent_data_manager,
+)
 
 
 @pytest.mark.asyncio
@@ -103,6 +103,25 @@ async def test_persistent_storage():
             print("✓ Cleanup completed")
         except Exception as e:
             print(f"⚠️  Cleanup warning: {e}")
+
+
+@pytest.mark.asyncio
+async def test_persistent_storage_uses_configured_data_dir(tmp_path, monkeypatch):
+    """Persistent storage should honor the deployment data directory."""
+    data_dir = tmp_path / "agent_state"
+    monkeypatch.setenv("PERSISTENT_DATA_DIR", str(data_dir))
+
+    manager = PersistentDataManager()
+    await manager.initialize()
+
+    try:
+        await manager.save_interaction(query="hello", response="world")
+
+        assert manager.data_dir == data_dir
+        assert manager.session_file.exists()
+        assert manager.interactions_db.exists()
+    finally:
+        await manager.cleanup()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- switch Coolify deployment metadata to Docker Compose so named persistent volumes are used
- add explicit runtime paths for ChromaDB memory, persistent state, knowledge, backups, scratchpad data, and logs
- make persistent session/SQLite storage configurable via `PERSISTENT_DATA_DIR`
- update deployment docs and ignore local data directories in Docker builds

## Root Cause

`docker-compose.yaml` already defined durable volumes, but `coolify.json` selected the Dockerfile build pack. A plain Dockerfile deployment can recreate the container without attaching the long-term memory and persistent state volumes, so ChromaDB memory and SQLite/session data may disappear after reboot or redeploy.

## Validation

- `python3 -m json.tool coolify.json`
- `docker compose config`
- `git diff --check HEAD~1 HEAD`

Full pytest was not run because this checkout has no local virtualenv and system Python is missing project dependencies such as `pytest` and `python-dotenv`.
